### PR TITLE
Modernize Dockerfile and bump base to ffmpeg-7.1.1-c

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'docs:') }}
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
-FROM sitespeedio/visualmetrics-deps:ffmpeg-7.1.1-b
+FROM sitespeedio/visualmetrics-deps:ffmpeg-7.1.1-c
 
 ARG TARGETPLATFORM
+ARG FIREFOX_VERSION=150.*
+ARG CHROME_VERSION=148.*
+ARG EDGE_VERSION=147.*
 
 ENV LC_ALL=C
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
-ENV FIREFOX_VERSION=150.*
-ENV CHROME_VERSION=148.*
-ENV EDGE_VERSION=147.*
-
 # Avoid ERROR: invoke-rc.d: policy-rc.d denied execution of start.
 # Avoid ERROR: invoke-rc.d: unknown initscript, /etc/init.d/systemd-logind not found.
 
-RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d && \
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/sbin/policy-rc.d && \
   touch /etc/init.d/systemd-logind
 
 COPY firefox/firefox-no-snap /etc/apt/preferences.d/firefox-no-snap
@@ -29,51 +28,46 @@ RUN fonts='fonts-ipafont-gothic fonts-ipafont-mincho ttf-wqy-microhei fonts-wqy-
   buildDeps='bzip2 gnupg wget ca-certificates curl gpg software-properties-common unzip' && \
   xvfbDeps='xvfb libgl1-mesa-dri xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic dbus-x11' && \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps --no-install-recommends && \
-  apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      android-tools-adb \
-      ca-certificates \
-      x11vnc \
-      sudo \
-      iproute2 \
-      $fonts \
-      $xvfbDeps \
-      --no-install-recommends
-
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; \
-      then \
-        wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-        echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
-        curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \
-        install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/  && \
-        sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'  && \
-        rm microsoft.gpg  && \
-        wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg -O- | sudo tee /etc/apt/keyrings/packages.mozilla.org.asc > /dev/null && \
-        echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" | sudo tee -a /etc/apt/sources.list.d/mozilla.list > /dev/null && \
-        apt-get update && \
-        apt-get install -y --no-install-recommends firefox=${FIREFOX_VERSION} && \
-        apt-get install -y google-chrome-stable=${CHROME_VERSION} && \
-        apt-get install -y microsoft-edge-stable=${EDGE_VERSION} &&  \
-        apt-get purge -y --auto-remove $buildDeps; \
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ] ; \
-        then \
-          # Get rid of that evil snap version of Firefox
-          rm -fR '/usr/bin/firefox' && \
-          apt remove --purge snapd -y && \
-          apt autoremove -y && \
-          rm -rf /var/lib/apt/lists/*  && \
-          add-apt-repository -y ppa:xtradeb/apps && \
-          apt-get update &&\
-          apt-get install -y --no-install-recommends ungoogled-chromium chromium-driver &&\
-          apt-get install -y -t 'o=LP-PPA-mozillateam' firefox && \
-          apt-get update && \
-          ln -s /usr/bin/ungoogled-chromium /usr/local/bin/google-chrome && \
-          ln -s /usr/bin/ungoogled-chromium /usr/local/bin/chromium && \
-          ln -s /usr/bin/ungoogled-chromiumdriver /usr/local/bin/chromedriver && \
-          apt-get purge -y --auto-remove $buildDeps; \
-    fi
-RUN apt-get clean autoclean && \
+  apt-get install -y --no-install-recommends \
+    $buildDeps \
+    android-tools-adb \
+    ca-certificates \
+    x11vnc \
+    sudo \
+    iproute2 \
+    $fonts \
+    $xvfbDeps && \
+  install -m 0755 -d /etc/apt/keyrings && \
+  if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+      wget -q -O- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/keyrings/google-chrome.gpg && \
+      echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+      wget -q -O- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/keyrings/microsoft.gpg && \
+      echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge.list && \
+      wget -q -O- https://packages.mozilla.org/apt/repo-signing-key.gpg > /etc/apt/keyrings/packages.mozilla.org.asc && \
+      echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" > /etc/apt/sources.list.d/mozilla.list && \
+      apt-get update && \
+      apt-get install -y --no-install-recommends \
+        firefox=${FIREFOX_VERSION} \
+        google-chrome-stable=${CHROME_VERSION} \
+        microsoft-edge-stable=${EDGE_VERSION}; \
+  elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+      # Get rid of that evil snap version of Firefox
+      rm -fR '/usr/bin/firefox' && \
+      apt-get remove --purge -y snapd && \
+      apt-get autoremove -y && \
+      rm -rf /var/lib/apt/lists/* && \
+      add-apt-repository -y ppa:xtradeb/apps && \
+      apt-get update && \
+      apt-get install -y --no-install-recommends ungoogled-chromium chromium-driver && \
+      apt-get install -y -t 'o=LP-PPA-mozillateam' firefox && \
+      ln -s /usr/bin/ungoogled-chromium /usr/local/bin/google-chrome && \
+      ln -s /usr/bin/ungoogled-chromium /usr/local/bin/chromium && \
+      ln -s /usr/bin/ungoogled-chromiumdriver /usr/local/bin/chromedriver; \
+  else \
+      echo "Unsupported TARGETPLATFORM: $TARGETPLATFORM" >&2 && exit 1; \
+  fi && \
+  apt-get purge -y --auto-remove $buildDeps && \
+  apt-get clean autoclean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # In the future sudo is fixed see https://github.com/sitespeedio/browsertime/issues/1105


### PR DESCRIPTION
  The browser-install steps were spread across three RUN layers, which
  meant apt-get purge --auto-remove $buildDeps only hid the build-only
  packages in a later layer instead of removing them from the image.
  Folding install + use + purge into a single RUN actually shrinks the
  shipped image.

  While there, drop the deprecated apt-key add for the Chrome repo and
  move both Chrome and Edge onto the per-source signed-by=/etc/apt/keyrings/...
  pattern that Mozilla already uses, so the build keeps working on newer
  Ubuntu bases where apt-key is gone. Also: create /etc/apt/keyrings
  before writing to it, replace echo "...\n..." with printf (dash's
  echo does not expand \n), drop the redundant apt-get update, switch
  apt→apt-get to silence the unstable-CLI warning, fail loudly on
  unknown TARGETPLATFORM instead of silently producing a browserless
  image, and move the browser version pins from ENV to ARG since they are
  only meaningful at build time.

  Bumps the base image to sitespeedio/visualmetrics-deps:ffmpeg-7.1.1-c.

  Co-authored-by: Claude noreply@anthropic.com